### PR TITLE
Base64 encoding instead of Hex

### DIFF
--- a/src/main/java/org/springframework/integration/aws/s3/core/AbstractAmazonS3Operations.java
+++ b/src/main/java/org/springframework/integration/aws/s3/core/AbstractAmazonS3Operations.java
@@ -27,6 +27,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.codec.binary.Base64;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -309,7 +311,7 @@ public abstract class AbstractAmazonS3Operations implements AmazonS3Operations, 
 		String stringContentMD5 = null;
 		try {
 			stringContentMD5 =
-					AWSCommonUtils.encodeHex(AWSCommonUtils.getContentsMD5AsBytes(file));
+					Base64.encodeBase64String(AWSCommonUtils.getContentsMD5AsBytes(file));
 		}
 		catch (UnsupportedEncodingException e) {
 			logger.error("Exception while generating the content's MD5 of the file " + file.getAbsolutePath(), e);


### PR DESCRIPTION
S3 expects the MD5 encoded as Base64 and not Hex.
